### PR TITLE
Fixed: moving projects outside of the solution directory fails

### DIFF
--- a/DotNetPlease.Tests/Commands/MoveProjectTests.cs
+++ b/DotNetPlease.Tests/Commands/MoveProjectTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System;
+using FluentAssertions;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -15,18 +16,23 @@ namespace DotNetPlease.Commands
     public class MoveProjectTests : TestFixtureBase
     {
         [Theory, CombinatorialData]
-        public async Task It_moves_project_file_and_directory(bool stage)
+        public async Task It_moves_project_file_and_directory(bool moveOutsideOfRootDirectory, bool stage)
         {
-            var originalProjectFileName = GetFullPath("OriginalProjectDirectory/OriginalProjectName.csproj");
-            CreateProject(originalProjectFileName);
-            var newProjectFileName = GetFullPath("NewProjectDirectory/NewProjectName.csproj");
+            var originalRelativePath = "OriginalProjectDirectory/OriginalProjectName.csproj";
+            var originalFullPath = GetFullPath(originalRelativePath);
+            CreateProject(originalFullPath);
+
+            var newRelativePath = moveOutsideOfRootDirectory 
+                ? $"../{Guid.NewGuid()}/NewSolution/NewProjectDirectory/NewProjectName.csproj"
+                : "NewProjectDirectory/NewProjectName.csproj";
+            var newFullPath = GetFullPath(newRelativePath);
 
             if (stage) CreateSnapshot();
 
             await RunAndAssertSuccess(
                 "move-project",
-                "OriginalProjectDirectory/OriginalProjectName.csproj",
-                "NewProjectDirectory/NewProjectName.csproj",
+                originalRelativePath,
+                newRelativePath,
                 StageOption(stage));
 
             if (stage)
@@ -35,27 +41,31 @@ namespace DotNetPlease.Commands
                 return;
             }
 
-            File.Exists(newProjectFileName).Should().BeTrue();
-            File.Exists(originalProjectFileName).Should().BeFalse();
-            Directory.Exists(Path.GetDirectoryName(originalProjectFileName)).Should().BeFalse();
+            File.Exists(newFullPath).Should().BeTrue();
+            File.Exists(originalFullPath).Should().BeFalse();
+            Directory.Exists(Path.GetDirectoryName(originalFullPath)).Should().BeFalse();
         }
 
         [Theory, CombinatorialData]
-        public async Task It_replaces_the_project_in_the_solution_file(bool stage)
+        public async Task It_replaces_the_project_in_the_solution_file(bool moveOutsideOfRootDirectory, bool stage)
         {
             var solutionFileName = GetFullPath("Test.sln");
             CreateSolution(solutionFileName);
-            var originalProjectFileName = GetFullPath("OriginalProjectDirectory/OriginalProjectName.csproj");
-            CreateProject(originalProjectFileName);
-            AddProjectToSolution(originalProjectFileName, solutionFileName);
-            var newProjectFileName = GetFullPath("NewProjectDirectory/NewProjectName.csproj");
+            var originalRelativePath = "OriginalProjectDirectory/OriginalProjectName.csproj";
+            var originalFullPath = GetFullPath(originalRelativePath);
+            CreateProject(originalFullPath);
+            AddProjectToSolution(originalFullPath, solutionFileName);
+            var newRelativePath = moveOutsideOfRootDirectory
+                ? $"../{Guid.NewGuid()}/NewSolution/NewProjectDirectory/NewProjectName.csproj"
+                : "NewProjectDirectory/NewProjectName.csproj";
+            var newFullPath = GetFullPath(newRelativePath);
 
             if (stage) CreateSnapshot();
 
             await RunAndAssertSuccess(
                 "move-project",
-                "OriginalProjectDirectory/OriginalProjectName.csproj",
-                "NewProjectDirectory/NewProjectName.csproj",
+                originalRelativePath,
+                newRelativePath,
                 "Test.sln",
                 StageOption(stage));
 
@@ -66,30 +76,35 @@ namespace DotNetPlease.Commands
             }
 
             var solution = LoadAndValidateSolution(solutionFileName);
-            var project = solution.ProjectsInOrder.FirstOrDefault(p => IsSamePath(p.AbsolutePath, newProjectFileName));
+            var project = solution.ProjectsInOrder.FirstOrDefault(p => IsSamePath(p.AbsolutePath, newFullPath));
             project.Should().NotBeNull();
             var oldProject =
-                solution.ProjectsInOrder.FirstOrDefault(p => IsSamePath(p.AbsolutePath, originalProjectFileName));
+                solution.ProjectsInOrder.FirstOrDefault(p => IsSamePath(p.AbsolutePath, originalFullPath));
             oldProject.Should().BeNull();
         }
 
         [Theory, CombinatorialData]
-        public async Task It_fixes_ProjectReferences(bool stage)
+        public async Task It_fixes_ProjectReferences(bool moveOutsideOfRootDirectory, bool stage)
         {
-            var originalProjectFileName = GetFullPath("OriginalProject/OriginalProject.csproj");
-            CreateProject(originalProjectFileName);
-            var referencedProjectFileName = GetFullPath("OtherProject/OtherProject.csproj");
-            CreateProject(referencedProjectFileName);
-            AddProjectReference(originalProjectFileName, referencedProjectFileName);
-            AddProjectReference(referencedProjectFileName, originalProjectFileName);
-            var newProjectFileName = GetFullPath("NewProjectDirectory/NewProjectName.csproj");
+            var originalRelativePath = "OriginalProject/OriginalProject.csproj";
+            var originalFullPath = GetFullPath(originalRelativePath);
+            CreateProject(originalFullPath);
+            var originalReferencePath = "OtherProject/OtherProject.csproj";
+                var referenceFullPath = GetFullPath(originalReferencePath);
+            CreateProject(referenceFullPath);
+            AddProjectReference(originalFullPath, referenceFullPath);
+            AddProjectReference(referenceFullPath, originalFullPath);
+            var newRelativePath = moveOutsideOfRootDirectory
+                ? $"../{Guid.NewGuid()}/NewSolution/NewProjectDirectory/NewProjectName.csproj"
+                : "NewProjectDirectory/NewProjectName.csproj";
+            var newFullPath = GetFullPath(newRelativePath);
 
             if (stage) CreateSnapshot();
 
             await RunAndAssertSuccess(
                 "move-project",
-                "OriginalProject/OriginalProject.csproj",
-                "NewProjectDirectory/NewProjectName.csproj",
+                originalRelativePath,
+                newRelativePath,
                 StageOption(stage));
 
             if (stage)
@@ -98,9 +113,9 @@ namespace DotNetPlease.Commands
                 return;
             }
 
-            FindProjectReference(newProjectFileName, referencedProjectFileName).Should().NotBeNull();
-            FindProjectReference(referencedProjectFileName, newProjectFileName).Should().NotBeNull();
-            FindProjectReference(referencedProjectFileName, originalProjectFileName).Should().BeNull();
+            FindProjectReference(newFullPath, referenceFullPath).Should().NotBeNull();
+            FindProjectReference(referenceFullPath, newFullPath).Should().NotBeNull();
+            FindProjectReference(referenceFullPath, originalFullPath).Should().BeNull();
         }
 
         public MoveProjectTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper)

--- a/DotNetPlease.Tests/Helpers/FileSystemHelperTests.cs
+++ b/DotNetPlease.Tests/Helpers/FileSystemHelperTests.cs
@@ -7,36 +7,50 @@ namespace DotNetPlease.Helpers
 
     public class FileSystemHelperTests
     {
-        [Fact]
-        public void IsSamePath_ignores_casing()
+        [Theory]
+        [InlineData("foo/bar", "Foo/BAR")]
+        public void IsSamePath_ignores_casing(string path1, string path2)
         {
-            IsSamePath("foo/bar", "Foo/BAR").Should().BeTrue();
+            IsSamePath(path1, path2).Should().BeTrue();
         }
 
-        [Fact]
-        public void IsSamePath_ignores_differences_in_path_separator()
+        [Theory]
+        [InlineData("foo/bar", "foo\\bar")]
+        public void IsSamePath_ignores_differences_in_path_separator(string path1, string path2)
         {
-            IsSamePath("foo/bar", "foo\\bar").Should().BeTrue();
+            IsSamePath(path1, path2).Should().BeTrue();
         }
 
-        [Fact]
-        public void IsSamePath_ignores_differences_in_trailing_path_separator()
+        [Theory]
+        [InlineData("foo/bar", "foo/bar/")]
+        [InlineData("foo/bar", "foo/bar\\")]
+        public void IsSamePath_ignores_differences_in_trailing_path_separator(string path1, string path2)
         {
-            IsSamePath("foo/bar", "foo/bar/").Should().BeTrue();
-            IsSamePath("foo/bar", "foo/bar\\").Should().BeTrue();
+            IsSamePath(path1, path2).Should().BeTrue();
         }
 
-        [Fact]
-        public void NormalizePath_replaces_backslash_with_forward_slash()
+        [Theory]
+        [InlineData("foo/bar/..", "foo")]
+        [InlineData("foo/bar/./baz", "foo/bar/baz")]
+        [InlineData("./foo/bar", "foo/bar")]
+        public void IsSamePath_ignores_redundant_relative_jumps(string path1, string path2)
         {
-            NormalizePath("foo\\bar/baz").Should().Be("foo/bar/baz");
+            IsSamePath(path1, path2).Should().BeTrue();
         }
 
-        [Fact]
-        public void NormalizePath_removes_trailing_path_separator()
+        [Theory]
+        [InlineData("foo\\bar/baz", "foo/bar/baz")]
+        public void NormalizePath_replaces_backslash_with_forward_slash(string oldPath, string newPath)
         {
-            NormalizePath("foo/bar/").Should().Be("foo/bar");
-            NormalizePath("foo\\bar\\").Should().Be("foo/bar");
+            NormalizePath(oldPath).Should().Be(newPath);
+        }
+
+        [Theory]
+        [InlineData("foo/bar/", "foo/bar")]
+        [InlineData("foo\\bar\\", "foo/bar")]
+        public void NormalizePath_removes_trailing_path_separator(string oldPath, string newPath)
+        {
+            NormalizePath(oldPath).Should().Be(newPath);
         }
     }
 }

--- a/DotNetPlease/Constants/CommandArguments.cs
+++ b/DotNetPlease/Constants/CommandArguments.cs
@@ -17,7 +17,7 @@
         public static class SolutionFileName
         {
             public const string Description =
-                "The solution file name (defaults to the solution in the working directory, or the working directory itself)";
+                "The solution file name (defaults to the solution in the working directory, if there is one)";
         }
 
         public static class RequiredSolutionFileName

--- a/DotNetPlease/Helpers/FileSystemHelper.cs
+++ b/DotNetPlease/Helpers/FileSystemHelper.cs
@@ -3,7 +3,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.Serialization;
 using System.Text.RegularExpressions;
 
 namespace DotNetPlease.Helpers
@@ -14,10 +13,11 @@ namespace DotNetPlease.Helpers
 
         public static bool IsSamePath(string path1, string path2)
         {
-            return string.Equals(NormalizePath(path1), NormalizePath(path2), StringComparison.OrdinalIgnoreCase);
+            return PathComparer.Equals(path1, path2);
         }
 
-        public static string NormalizePath(string? path) => DirectorySeparatorRegex.Replace(path ?? "", "/").TrimEnd('/');
+        public static string NormalizePath(string? path) =>
+            DirectorySeparatorRegex.Replace(path ?? "", "/").TrimEnd('/');
 
         public static readonly StringComparer PathComparer = new PathComparerImpl();
 
@@ -44,7 +44,7 @@ namespace DotNetPlease.Helpers
                 File.Copy(fileName, destFileName, overwrite: true);
             }
         }
-        
+
         /// <summary>
         /// Find a file closest to the working directory in the directory tree (like Directory.Build.props)
         /// </summary>
@@ -72,14 +72,17 @@ namespace DotNetPlease.Helpers
 
             return null;
         }
-        
+
         private class PathComparerImpl : StringComparer
         {
             public override int Compare(string? x, string? y)
             {
                 if (string.IsNullOrWhiteSpace(x) && string.IsNullOrWhiteSpace(y))
                     return 0;
-                return string.Compare(NormalizePath(x), NormalizePath(y), StringComparison.OrdinalIgnoreCase);
+                return string.Compare(
+                    Path.GetFullPath(NormalizePath(x)), 
+                    Path.GetFullPath(NormalizePath(y)),
+                    StringComparison.OrdinalIgnoreCase);
             }
 
             public override bool Equals(string? x, string? y)
@@ -88,14 +91,18 @@ namespace DotNetPlease.Helpers
                     return string.IsNullOrWhiteSpace(y);
                 if (string.IsNullOrWhiteSpace(y))
                     return false;
-                return IsSamePath(x, y);
+
+                return string.Equals(
+                    Path.GetFullPath(NormalizePath(x)),
+                    Path.GetFullPath(NormalizePath(y)),
+                    StringComparison.OrdinalIgnoreCase);
             }
 
             public override int GetHashCode(string obj)
             {
                 if (string.IsNullOrWhiteSpace(obj))
                     return 0;
-                obj = NormalizePath(obj);
+                obj = Path.GetFullPath(NormalizePath(obj));
                 return obj.GetHashCode(StringComparison.OrdinalIgnoreCase);
             }
         }

--- a/DotNetPlease/Internal/Workspace.FileSystem.cs
+++ b/DotNetPlease/Internal/Workspace.FileSystem.cs
@@ -130,6 +130,7 @@ namespace DotNetPlease.Internal
 
             try
             {
+                Directory.CreateDirectory(Path.GetDirectoryName(newPath));
                 Directory.Move(oldPath, newPath);
                 Reporter.Success($"{completedVerb} \"{oldRelativePath}\" to \"{newNameOrRelativePath}\"");
                 return true;


### PR DESCRIPTION
Improvement: `IsSamePath` now correctly handles redundant relative jumps