### PR TITLE
Disable .NET dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,11 @@
 
 version: 2
 updates:
-  # Maintain dependencies for .NET
-  - package-ecosystem: "nuget"
-    directory: "/"
-    schedule:
-      interval: "monthly"
+  # Disable dependencies for .NET until lock file support is added
+  #- package-ecosystem: "nuget"
+  #  directory: "/"
+  #  schedule:
+  #    interval: "monthly"
 
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Lock files are not supported yet so disable until supported