### PR TITLE
Fix hard-coded v16 in `remove-junk`

### DIFF
--- a/DotNetPlease.Tests/Commands/RemoveJunkTests.cs
+++ b/DotNetPlease.Tests/Commands/RemoveJunkTests.cs
@@ -12,6 +12,7 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.Reflection.Metadata;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Xunit;
@@ -111,6 +112,49 @@ namespace DotNetPlease.Commands
 
             Directory.Exists(projectDirectory + "/assets/bin").Should().BeTrue();
             Directory.Exists(WorkingDirectory + "/bin").Should().BeTrue();
+        }
+
+        [Theory, CombinatorialData]
+        public async Task It_removes_the_TestStore_directory([CombinatorialValues("v16", "v17")]string vsVersion, bool dryRun)
+        {
+            var solutionFileName = GetFullPath("Test.sln");
+            CreateSolution(solutionFileName);
+            var directoryToDelete = Path.Combine(WorkingDirectory, ".vs", "Test", vsVersion, "TestStore");
+            Directory.CreateDirectory(directoryToDelete);
+
+            if (dryRun) CreateSnapshot();
+
+            await RunAndAssertSuccess("remove-junk", "--testStore", DryRunOption(dryRun));
+
+            if (dryRun)
+            {
+                VerifySnapshot();
+                return;
+            }
+
+            Directory.Exists(directoryToDelete).Should().BeFalse();
+        }
+
+        [Theory, CombinatorialData]
+        public async Task It_removes_the_suo_file([CombinatorialValues("v16", "v17")] string vsVersion, bool dryRun)
+        {
+            var solutionFileName = GetFullPath("Test.sln");
+            CreateSolution(solutionFileName);
+            var fileToDelete = Path.Combine(WorkingDirectory, ".vs", "Test", vsVersion, ".suo");
+            Directory.CreateDirectory(Path.GetDirectoryName(fileToDelete));
+            File.Create(fileToDelete).Dispose();
+
+            if (dryRun) CreateSnapshot();
+
+            await RunAndAssertSuccess("remove-junk", "--suo", DryRunOption(dryRun));
+
+            if (dryRun)
+            {
+                VerifySnapshot();
+                return;
+            }
+
+            File.Exists(fileToDelete).Should().BeFalse();
         }
 
         public RemoveJunkTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper)

--- a/DotNetPlease.Tests/Commands/TestFixtureBase.cs
+++ b/DotNetPlease.Tests/Commands/TestFixtureBase.cs
@@ -34,6 +34,24 @@ namespace DotNetPlease.Commands
     [Collection("cwd")]
     public class TestFixtureBase : IDisposable
     {
+        //[Theory, CombinatorialData]
+        //public async Task Template_test(bool dryRun)
+        //{
+        //    // Arrange workspace 
+
+        //    if (dryRun) CreateSnapshot();
+
+        //    await RunAndAssertSuccess("command", "--switch", "argument", DryRunOption(dryRun));
+
+        //    if (dryRun)
+        //    {
+        //        VerifySnapshot();
+        //        return;
+        //    }
+
+        //    // Assert
+        //}
+
         protected readonly string WorkingDirectory;
 
         protected readonly TestOutputReporter TestOutputReporter;

--- a/DotNetPlease/Commands/RemoveJunk.cs
+++ b/DotNetPlease/Commands/RemoveJunk.cs
@@ -15,11 +15,11 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using DotNetPlease.Annotations;
-using DotNetPlease.Helpers;
 using DotNetPlease.Internal;
 using DotNetPlease.Services.Reporting.Abstractions;
 using JetBrains.Annotations;
 using MediatR;
+using static DotNetPlease.Helpers.MSBuildHelper;
 
 namespace DotNetPlease.Commands
 {
@@ -74,8 +74,10 @@ namespace DotNetPlease.Commands
                     return;
                 }
 
-                var path = Path.Combine(MSBuildHelper.GetHiddenVsDirectory(context.SolutionFileName), "v16/.suo");
-                TryDeleteFile(path, context);
+                foreach (var dir in GetHiddenVSFiles(context.SolutionFileName, ".suo"))
+                {
+                    TryDeleteFile(dir, context);
+                }
             }
 
             private void RemoveTestStore(Context context)
@@ -85,8 +87,11 @@ namespace DotNetPlease.Commands
                     Reporter.Warning("Test Store can only be removed from solutions");
                     return;
                 }
-                var path = Path.Combine(MSBuildHelper.GetHiddenVsDirectory(context.SolutionFileName), $"v16/TestStore");
-                TryDeleteDirectory(path, context);
+
+                foreach (var dir in GetHiddenVSDirectories(context.SolutionFileName, "TestStore"))
+                {
+                    TryDeleteDirectory(dir, context);
+                }
             }
 
             private void RemoveBinFolders(Context context)


### PR DESCRIPTION
This bug fell through the holes as there were no tests for `remove-junk --suo --testStore`
VS version 16 was hard coded, now it's a regex