### PR TITLE
Fix application crashing on Linux

### DIFF
--- a/DotNetPlease/App.cs
+++ b/DotNetPlease/App.cs
@@ -65,8 +65,8 @@ namespace DotNetPlease
         {
             using var scope = ServiceProvider.CreateScope();
             var parser = BuildCommandLineParser();
-            var cursorVisible = !Console.IsOutputRedirected && Console.CursorVisible;
-            if (!Console.IsOutputRedirected)
+            var cursorVisible = !Console.IsOutputRedirected && OperatingSystem.IsWindows() && Console.CursorVisible;
+            if (!Console.IsOutputRedirected && OperatingSystem.IsWindows())
             {
                 Console.CursorVisible = false;
             }
@@ -84,7 +84,7 @@ namespace DotNetPlease
             }
             finally
             {
-                if (!Console.IsOutputRedirected)
+                if (!Console.IsOutputRedirected && OperatingSystem.IsWindows())
                 {
                     Console.CursorVisible = cursorVisible;
                 }

--- a/DotNetPlease/DotNetPlease.csproj
+++ b/DotNetPlease/DotNetPlease.csproj
@@ -26,9 +26,9 @@
 	<ItemGroup>
 		<PackageReference Include="JetBrains.Annotations" Version="2023.3.0" />
 		<PackageReference Include="MediatR" Version="12.2.0" />
-		<PackageReference Include="Microsoft.Build" Version="17.10.4" />
-		<PackageReference Include="Microsoft.Build.Framework" Version="17.10.4" />
-		<PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.10.4" />
+		<PackageReference Include="Microsoft.Build" Version="17.11.4" />
+		<PackageReference Include="Microsoft.Build.Framework" Version="17.11.4" />
+		<PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.11.4" />
 		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="8.0.0" />

--- a/DotNetPlease/packages.lock.json
+++ b/DotNetPlease/packages.lock.json
@@ -20,34 +20,32 @@
       },
       "Microsoft.Build": {
         "type": "Direct",
-        "requested": "[17.10.4, )",
-        "resolved": "17.10.4",
-        "contentHash": "ZmGA8vhVXFzC4oo48ybQKlEybVKd0Ntfdr+Enqrn5ES1R6e/krIK9hLk0W33xuT0/G6QYd3YdhJZh+Xle717Ag==",
+        "requested": "[17.11.4, )",
+        "resolved": "17.11.4",
+        "contentHash": "UMC7DfeFEHY2GGHHaghybUuUlLaByFHEFudR2PehMgDBuRuLAUePp1iaa4eFtVzepRzMtIbeSCVJCzzX3NV2Gg==",
         "dependencies": {
-          "Microsoft.Build.Framework": "17.10.4",
-          "Microsoft.NET.StringTools": "17.10.4",
+          "Microsoft.Build.Framework": "17.11.4",
+          "Microsoft.NET.StringTools": "17.11.4",
           "System.Collections.Immutable": "8.0.0",
           "System.Configuration.ConfigurationManager": "8.0.0",
           "System.Reflection.Metadata": "8.0.0",
-          "System.Reflection.MetadataLoadContext": "8.0.0",
-          "System.Security.Principal.Windows": "5.0.0",
-          "System.Threading.Tasks.Dataflow": "8.0.0"
+          "System.Reflection.MetadataLoadContext": "8.0.0"
         }
       },
       "Microsoft.Build.Framework": {
         "type": "Direct",
-        "requested": "[17.10.4, )",
-        "resolved": "17.10.4",
-        "contentHash": "4qXCwNOXBR1dyCzuks9SwTwFJQO/xmf2wcMislotDWJu7MN/r3xDNoU8Ae5QmKIHPaLG1xmfDkYS7qBVzxmeKw=="
+        "requested": "[17.11.4, )",
+        "resolved": "17.11.4",
+        "contentHash": "u28uDihlqxtt8h2dL1ZJOZ7TRkxBK+HGr+3FgQpILVo7Q7gErkw8mYW9R+RM5PtxvZTdYb/4MWDL66vdIsANBQ=="
       },
       "Microsoft.Build.Utilities.Core": {
         "type": "Direct",
-        "requested": "[17.10.4, )",
-        "resolved": "17.10.4",
-        "contentHash": "eEB/tcXkSV+nQgvoa/l53UPtn+KVtKZ8zBceDZsXVTrfE4fA+4+/olrx9W8n2tq4XiESsL9UuGJgCKzqBwQCoQ==",
+        "requested": "[17.11.4, )",
+        "resolved": "17.11.4",
+        "contentHash": "b2CEJMgVuv5fkhaR6TXjgocIa6YQbseowRj15q3/IyH343EPr+CrxXAZs6Xp6uZDE8A3ynsLPlufFUMkjUl37A==",
         "dependencies": {
-          "Microsoft.Build.Framework": "17.10.4",
-          "Microsoft.NET.StringTools": "17.10.4",
+          "Microsoft.Build.Framework": "17.11.4",
+          "Microsoft.NET.StringTools": "17.11.4",
           "System.Collections.Immutable": "8.0.0",
           "System.Configuration.ConfigurationManager": "8.0.0"
         }
@@ -126,8 +124,8 @@
       },
       "Microsoft.NET.StringTools": {
         "type": "Transitive",
-        "resolved": "17.10.4",
-        "contentHash": "wyABaqY+IHCMMSTQmcc3Ca6vbmg5BaEPgicnEgpll+4xyWZWlkQqUwafweUd9VAhBb4jqplMl6voUHQ6yfdUcg=="
+        "resolved": "17.11.4",
+        "contentHash": "mudqUHhNpeqIdJoUx2YDWZO/I9uEDYVowan89R6wsomfnUJQk6HteoQTlNjZDixhT2B4IXMkMtgZtoceIjLRmA=="
       },
       "Microsoft.NETCore.Platforms": {
         "type": "Transitive",
@@ -201,11 +199,6 @@
         "resolved": "8.0.0",
         "contentHash": "+TUFINV2q2ifyXauQXRwy4CiBhqvDEDZeVJU7qfxya4aRYOKzVBpN+4acx25VcPB9ywUN6C0n8drWl110PhZEg=="
       },
-      "System.Security.Principal.Windows": {
-        "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "t0MGLukB5WAVU9bO3MGzvlGnyJPgUlcwerXn1kzBRjwLKixT96XV0Uza41W49gVd8zEMFu9vQEFlv0IOrytICA=="
-      },
       "System.Text.Encoding": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -225,11 +218,6 @@
           "Microsoft.NETCore.Targets": "1.1.0",
           "System.Runtime": "4.3.0"
         }
-      },
-      "System.Threading.Tasks.Dataflow": {
-        "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "7V0I8tPa9V7UxMx/+7DIwkhls5ouaEMQx6l/GwGm1Y8kJQ61On9B/PxCXFLbgu5/C47g0BP2CUYs+nMv1+Oaqw=="
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ Then to get the list of available commands:
 please --help
 ```
 
+### Installing on Ubuntu Linux
+
+This project uses MSBuild assemblies from Microsoft that don't seem to work when the
+.NET SDK is installed using Snap. If you encounter errors like this one:
+```
+
+```
+...then try installing the SDK from the official Ubuntu package feed ([instructions](https://learn.microsoft.com/en-us/dotnet/core/install/linux-ubuntu#supported-distributions))
+
 ## Usage
 
 Open a command prompt, navigate to your solution's root directory, and start


### PR DESCRIPTION
Note: the MSBuild package versions in this commit are the latest that support .NET 8. Newer packages only target .NET 9 and .NET Framework.
Also note that the MSBuild packages don't seem to work when the .NET SDK is 
Closes #47
Closes #109