### PR TITLE
Add create-solution-filters command for converting multiple solutions

### DIFF
--- a/DotNetPlease.Tests/Commands/CreateSolutionFiltersTests.cs
+++ b/DotNetPlease.Tests/Commands/CreateSolutionFiltersTests.cs
@@ -1,0 +1,240 @@
+// Morgan Stanley makes this available to you under the Apache License,
+// Version 2.0 (the "License"). You may obtain a copy of the License at
+// 
+//      http://www.apache.org/licenses/LICENSE-2.0.
+// 
+// See the NOTICE file distributed with this work for additional information
+// regarding copyright ownership. Unless agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+using static DotNetPlease.Helpers.DotNetCliHelper;
+using static DotNetPlease.Helpers.MSBuildHelper;
+
+namespace DotNetPlease.Commands;
+
+public class CreateSolutionFiltersTests : TestFixtureBase
+{
+    [Theory, CombinatorialData]
+    public async Task It_consolidates_two_solutions_into_one_with_filters(bool dryRun)
+    {
+        // Arrange
+        var solution1Path = GetFullPath("Solution1/Solution1.sln");
+        CreateSolution(solution1Path);
+        var project1Path = GetFullPath("Solution1/Project1/Project1.csproj");
+        CreateProject(project1Path);
+        AddProjectToSolution(project1Path, solution1Path);
+
+        var solution2Path = GetFullPath("Solution2/Solution2.sln");
+        CreateSolution(solution2Path);
+        var project2Path = GetFullPath("Solution2/Project2/Project2.csproj");
+        CreateProject(project2Path);
+        AddProjectToSolution(project2Path, solution2Path);
+
+        var targetSolutionPath = GetFullPath("Consolidated.sln");
+
+        if (dryRun) CreateSnapshot();
+
+        // Act
+        await RunAndAssertSuccess(
+            "create-solution-filters",
+            "--from", "Solution*/Solution*.sln",
+            "--target", "Consolidated.sln",
+            DryRunOption(dryRun));
+
+        // Assert
+        if (dryRun)
+        {
+            VerifySnapshot();
+            return;
+        }
+
+        File.Exists(targetSolutionPath).Should().BeTrue("Target solution should be created");
+
+        var projectsInTarget = GetProjectsFromSolution(targetSolutionPath);
+        projectsInTarget.Should().Contain(project1Path, "Project1 should be in target");
+        projectsInTarget.Should().Contain(project2Path, "Project2 should be in target");
+
+        File.Exists(solution1Path).Should().BeFalse("Source solution 1 should be deleted");
+        File.Exists(solution2Path).Should().BeFalse("Source solution 2 should be deleted");
+
+        var filter1Path = Path.ChangeExtension(solution1Path, ".slnf");
+        var filter2Path = Path.ChangeExtension(solution2Path, ".slnf");
+        File.Exists(filter1Path).Should().BeTrue("Solution1.slnf should be created");
+        File.Exists(filter2Path).Should().BeTrue("Solution2.slnf should be created");
+
+        VerifyFilterFile(filter1Path, "Solution1", targetSolutionPath, new[] { project1Path });
+        VerifyFilterFile(filter2Path, "Solution2", targetSolutionPath, new[] { project2Path });
+    }
+
+    [Theory, CombinatorialData]
+    public async Task It_uses_existing_target_solution(bool dryRun)
+    {
+        // Arrange
+        var targetSolutionPath = GetFullPath("Consolidated.sln");
+        CreateSolution(targetSolutionPath);
+
+        var solution1Path = GetFullPath("Solution1/Solution1.sln");
+        CreateSolution(solution1Path);
+        var project1Path = GetFullPath("Solution1/Project1/Project1.csproj");
+        CreateProject(project1Path);
+        AddProjectToSolution(project1Path, solution1Path);
+
+        var solution2Path = GetFullPath("Solution2/Solution2.sln");
+        CreateSolution(solution2Path);
+        var project2Path = GetFullPath("Solution2/Project2/Project2.csproj");
+        CreateProject(project2Path);
+        AddProjectToSolution(project2Path, solution2Path);
+
+        if (dryRun) CreateSnapshot();
+
+        // Act
+        await RunAndAssertSuccess(
+            "create-solution-filters",
+            "--from", "Solution*/Solution*.sln",
+            "--target", "Consolidated.sln",
+            DryRunOption(dryRun));
+
+        // Assert
+        if (dryRun)
+        {
+            VerifySnapshot();
+            return;
+        }
+
+        var projectsInTarget = GetProjectsFromSolution(targetSolutionPath);
+        projectsInTarget.Should().Contain(project1Path);
+        projectsInTarget.Should().Contain(project2Path);
+    }
+
+    [Theory, CombinatorialData]
+    public async Task It_handles_multiple_projects_per_solution(bool dryRun)
+    {
+        // Arrange
+        var solution1Path = GetFullPath("Solution1/Solution1.sln");
+        CreateSolution(solution1Path);
+        var project1APath = GetFullPath("Solution1/ProjectA/ProjectA.csproj");
+        var project1BPath = GetFullPath("Solution1/ProjectB/ProjectB.csproj");
+        CreateProject(project1APath);
+        CreateProject(project1BPath);
+        AddProjectToSolution(project1APath, solution1Path);
+        AddProjectToSolution(project1BPath, solution1Path);
+
+        var solution2Path = GetFullPath("Solution2/Solution2.sln");
+        CreateSolution(solution2Path);
+        var project2APath = GetFullPath("Solution2/ProjectC/ProjectC.csproj");
+        var project2BPath = GetFullPath("Solution2/ProjectD/ProjectD.csproj");
+        CreateProject(project2APath);
+        CreateProject(project2BPath);
+        AddProjectToSolution(project2APath, solution2Path);
+        AddProjectToSolution(project2BPath, solution2Path);
+
+        var targetSolutionPath = GetFullPath("Consolidated.sln");
+
+        if (dryRun) CreateSnapshot();
+
+        // Act
+        await RunAndAssertSuccess(
+            "create-solution-filters",
+            "--from", "Solution*/Solution*.sln",
+            "--target", "Consolidated.sln",
+            DryRunOption(dryRun));
+
+        // Assert
+        if (dryRun)
+        {
+            VerifySnapshot();
+            return;
+        }
+
+        var projectsInTarget = GetProjectsFromSolution(targetSolutionPath);
+        projectsInTarget.Should().Contain(new[] { project1APath, project1BPath, project2APath, project2BPath });
+
+        VerifyFilterFile(Path.ChangeExtension(solution1Path, ".slnf"), "Solution1", targetSolutionPath, new[] { project1APath, project1BPath });
+        VerifyFilterFile(Path.ChangeExtension(solution2Path, ".slnf"), "Solution2", targetSolutionPath, new[] { project2APath, project2BPath });
+    }
+
+    [Theory, CombinatorialData]
+    public async Task It_handles_single_solution(bool dryRun)
+    {
+        // Arrange
+        var solution1Path = GetFullPath("Solution1/Solution1.sln");
+        CreateSolution(solution1Path);
+        var project1Path = GetFullPath("Solution1/Project1/Project1.csproj");
+        CreateProject(project1Path);
+        AddProjectToSolution(project1Path, solution1Path);
+
+        var targetSolutionPath = GetFullPath("Consolidated.sln");
+
+        if (dryRun) CreateSnapshot();
+
+        // Act
+        await RunAndAssertSuccess(
+            "create-solution-filters",
+            "--from", "Solution*/Solution*.sln",
+            "--target", "Consolidated.sln",
+            DryRunOption(dryRun));
+
+        // Assert
+        if (dryRun)
+        {
+            VerifySnapshot();
+            return;
+        }
+
+        File.Exists(targetSolutionPath).Should().BeTrue();
+        var projectsInTarget = GetProjectsFromSolution(targetSolutionPath);
+        projectsInTarget.Should().Contain(project1Path);
+
+        var filterPath = Path.ChangeExtension(solution1Path, ".slnf");
+        File.Exists(filterPath).Should().BeTrue();
+        VerifyFilterFile(filterPath, "Solution1", targetSolutionPath, new[] { project1Path });
+    }
+
+    private void VerifyFilterFile(string filterPath, string expectedFilterName, string targetSolutionPath, string[] expectedProjectPaths)
+    {
+        File.Exists(filterPath).Should().BeTrue($"Filter file {filterPath} should exist");
+
+        var json = File.ReadAllText(filterPath);
+        var filter = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
+
+        filter.Should().NotBeNull();
+        filter.Should().ContainKey("version");
+        ((JsonElement)filter!["defaultFilter"]).GetString().Should().Be(expectedFilterName);
+        filter.Should().ContainKey("filters");
+
+        var filtersObj = (JsonElement)filter["filters"];
+        filtersObj.TryGetProperty(expectedFilterName, out var filterDef).Should().BeTrue();
+
+        var targetDir = Path.GetDirectoryName(targetSolutionPath)!;
+        var expectedRelativePath = Path.GetRelativePath(targetDir, targetSolutionPath);
+        
+        filterDef.TryGetProperty("path", out var pathElement).Should().BeTrue();
+        pathElement.GetString().Should().Be(expectedRelativePath);
+
+        filterDef.TryGetProperty("includes", out var includesElement).Should().BeTrue();
+        var includes = includesElement.EnumerateArray().Select(e => e.GetString()).ToList();
+        
+        var expectedIncludes = expectedProjectPaths
+            .Select(p => Path.GetRelativePath(targetDir, p))
+            .OrderBy(p => p)
+            .ToList();
+
+        includes.Should().BeEquivalentTo(expectedIncludes);
+    }
+
+    public CreateSolutionFiltersTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
+    {
+    }
+}

--- a/DotNetPlease.Tests/Commands/CreateSolutionFiltersTests.cs
+++ b/DotNetPlease.Tests/Commands/CreateSolutionFiltersTests.cs
@@ -207,31 +207,26 @@ public class CreateSolutionFiltersTests : TestFixtureBase
         File.Exists(filterPath).Should().BeTrue($"Filter file {filterPath} should exist");
 
         var json = File.ReadAllText(filterPath);
-        var filter = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
+        using var filter = JsonDocument.Parse(json);
 
-        filter.Should().NotBeNull();
-        filter.Should().ContainKey("version");
-        ((JsonElement)filter!["defaultFilter"]).GetString().Should().Be(expectedFilterName);
-        filter.Should().ContainKey("filters");
+        var root = filter.RootElement;
+        root.TryGetProperty("solution", out var solutionElement).Should().BeTrue();
 
-        var filtersObj = (JsonElement)filter["filters"];
-        filtersObj.TryGetProperty(expectedFilterName, out var filterDef).Should().BeTrue();
+        var filterDir = Path.GetDirectoryName(filterPath)!;
+        var expectedRelativePath = Path.GetRelativePath(filterDir, targetSolutionPath);
 
-        var targetDir = Path.GetDirectoryName(targetSolutionPath)!;
-        var expectedRelativePath = Path.GetRelativePath(targetDir, targetSolutionPath);
-        
-        filterDef.TryGetProperty("path", out var pathElement).Should().BeTrue();
+        solutionElement.TryGetProperty("path", out var pathElement).Should().BeTrue();
         pathElement.GetString().Should().Be(expectedRelativePath);
 
-        filterDef.TryGetProperty("includes", out var includesElement).Should().BeTrue();
-        var includes = includesElement.EnumerateArray().Select(e => e.GetString()).ToList();
-        
-        var expectedIncludes = expectedProjectPaths
-            .Select(p => Path.GetRelativePath(targetDir, p))
+        solutionElement.TryGetProperty("projects", out var projectsElement).Should().BeTrue();
+        var projects = projectsElement.EnumerateArray().Select(e => e.GetString()).ToList();
+
+        var expectedProjects = expectedProjectPaths
+            .Select(p => Path.GetRelativePath(filterDir, p))
             .OrderBy(p => p)
             .ToList();
 
-        includes.Should().BeEquivalentTo(expectedIncludes);
+        projects.Should().BeEquivalentTo(expectedProjects);
     }
 
     public CreateSolutionFiltersTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper)

--- a/DotNetPlease/Commands/CreateSolutionFilters.cs
+++ b/DotNetPlease/Commands/CreateSolutionFilters.cs
@@ -54,12 +54,20 @@ public static class CreateSolutionFilters
 
         public override ValueTask<Unit> Handle(Command command, CancellationToken cancellationToken)
         {
+            // Validate target is a .sln file
+            if (!command.Target.EndsWith(".sln", StringComparison.OrdinalIgnoreCase))
+            {
+                Reporter.Error("Target must be a .sln file (e.g., Consolidated.sln)");
+                return ValueTask.FromResult(Unit.Value);
+            }
+
             var context = new Context
             {
                 Command = command,
                 SourceSolutions = new List<string>(),
                 TargetSolutionPath = Path.Combine(Workspace.WorkingDirectory, command.Target),
-                ProjectsBySource = new Dictionary<string, List<string>>()
+                ProjectsBySource = new Dictionary<string, List<string>>(),
+                AddedProjects = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
             };
 
             DiscoverSourceSolutions(context);
@@ -72,6 +80,10 @@ public static class CreateSolutionFilters
 
             ExtractProjectsFromSources(context);
             CreateOrValidateTargetSolution(context);
+            
+            // Remove target solution from cleanup list to prevent accidental deletion
+            context.SourceSolutions.Remove(context.TargetSolutionPath);
+            
             ConsolidateProjectsToTarget(context);
             GenerateSolutionFilters(context);
             CleanupSourceSolutions(context);
@@ -150,6 +162,13 @@ public static class CreateSolutionFilters
 
                     foreach (var project in projects)
                     {
+                        // Skip duplicate projects
+                        if (context.AddedProjects.Contains(project))
+                        {
+                            Reporter.Info($"  {Workspace.GetRelativePath(project)} (already added)");
+                            continue;
+                        }
+
                         var projectRelativePath = Workspace.GetRelativePath(project);
                         
                         if (!Workspace.IsDryRun)
@@ -160,6 +179,7 @@ public static class CreateSolutionFilters
                                 solutionFolderName);
                         }
 
+                        context.AddedProjects.Add(project);
                         Reporter.Success($"  {projectRelativePath} -> {solutionFolderName}");
                     }
                 }
@@ -170,34 +190,25 @@ public static class CreateSolutionFilters
         {
             Reporter.Info("Generating solution filter files");
 
-            var targetSolutionRelativePath = Workspace.GetRelativePath(context.TargetSolutionPath);
-            var targetSolutionDirectory = Path.GetDirectoryName(context.TargetSolutionPath)!;
-
             foreach (var sourceSolution in context.SourceSolutions)
             {
                 var filterFileName = Path.ChangeExtension(sourceSolution, ".slnf");
-                var filterName = Path.GetFileNameWithoutExtension(sourceSolution);
                 var projects = context.ProjectsBySource[sourceSolution];
+                var filterDir = Path.GetDirectoryName(filterFileName)!;
 
+                // Compute paths relative to the .slnf file location
+                var relativeSolutionPath = Path.GetRelativePath(filterDir, context.TargetSolutionPath);
                 var projectIncludePaths = projects
-                    .Select(p => Path.GetRelativePath(targetSolutionDirectory, p))
+                    .Select(p => Path.GetRelativePath(filterDir, p))
                     .OrderBy(p => p)
                     .ToList();
 
                 var filter = new SolutionFilterJson
                 {
-                    Version = "0.1",
-                    DefaultFilter = filterName,
-                    Filters = new Dictionary<string, FilterDefinition>
+                    Solution = new SolutionElement
                     {
-                        {
-                            filterName,
-                            new FilterDefinition
-                            {
-                                Path = Path.GetRelativePath(targetSolutionDirectory, context.TargetSolutionPath),
-                                Includes = projectIncludePaths
-                            }
-                        }
+                        Path = relativeSolutionPath,
+                        Projects = projectIncludePaths
                     }
                 };
 
@@ -236,19 +247,18 @@ public static class CreateSolutionFilters
             public List<string> SourceSolutions { get; set; } = null!;
             public string TargetSolutionPath { get; set; } = null!;
             public Dictionary<string, List<string>> ProjectsBySource { get; set; } = null!;
+            public HashSet<string> AddedProjects { get; set; } = null!;
         }
 
         private class SolutionFilterJson
         {
-            public string? Version { get; set; }
-            public string? DefaultFilter { get; set; }
-            public Dictionary<string, FilterDefinition>? Filters { get; set; }
+            public SolutionElement? Solution { get; set; }
         }
 
-        private class FilterDefinition
+        private class SolutionElement
         {
             public string? Path { get; set; }
-            public List<string>? Includes { get; set; }
+            public List<string>? Projects { get; set; }
         }
     }
 }

--- a/DotNetPlease/Commands/CreateSolutionFilters.cs
+++ b/DotNetPlease/Commands/CreateSolutionFilters.cs
@@ -1,0 +1,255 @@
+// Morgan Stanley makes this available to you under the Apache License,
+// Version 2.0 (the "License"). You may obtain a copy of the License at
+// 
+//      http://www.apache.org/licenses/LICENSE-2.0.
+// 
+// See the NOTICE file distributed with this work for additional information
+// regarding copyright ownership. Unless required by applicable law or agreed
+// to in writing, software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions
+// and limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using DotNetPlease.Annotations;
+using DotNetPlease.Helpers;
+using DotNetPlease.Internal;
+using DotNetPlease.Services.Reporting.Abstractions;
+using JetBrains.Annotations;
+using Mediator;
+using Microsoft.Build.Construction;
+using static DotNetPlease.Helpers.MSBuildHelper;
+
+namespace DotNetPlease.Commands;
+
+public static class CreateSolutionFilters
+{
+    [Command(
+        "create-solution-filters",
+        "Converts multiple solutions to a single solution with solution filter files")]
+    public class Command : IRequest
+    {
+        [Option("--from", "Globbing pattern for source .sln files")]
+        [Required]
+        public string From { get; set; } = null!;
+
+        [Option("--target", "Target solution file name")]
+        [Required]
+        public string Target { get; set; } = null!;
+    }
+
+    [UsedImplicitly]
+    public class CommandHandler : CommandHandlerBase<Command>
+    {
+        public CommandHandler(CommandHandlerDependencies dependencies) : base(dependencies)
+        {
+        }
+
+        public override ValueTask<Unit> Handle(Command command, CancellationToken cancellationToken)
+        {
+            var context = new Context
+            {
+                Command = command,
+                SourceSolutions = new List<string>(),
+                TargetSolutionPath = Path.Combine(Workspace.WorkingDirectory, command.Target),
+                ProjectsBySource = new Dictionary<string, List<string>>()
+            };
+
+            DiscoverSourceSolutions(context);
+            
+            if (context.SourceSolutions.Count == 0)
+            {
+                Reporter.Error($"No solutions found matching pattern: {command.From}");
+                return ValueTask.FromResult(Unit.Value);
+            }
+
+            ExtractProjectsFromSources(context);
+            CreateOrValidateTargetSolution(context);
+            ConsolidateProjectsToTarget(context);
+            GenerateSolutionFilters(context);
+            CleanupSourceSolutions(context);
+
+            Reporter.Success("Solution filter conversion completed successfully");
+            return ValueTask.FromResult(Unit.Value);
+        }
+
+        private void DiscoverSourceSolutions(Context context)
+        {
+            Reporter.Info("Discovering source solutions");
+
+            var projectInfos = GetProjectInfosFromGlob(
+                context.Command.From,
+                Workspace.WorkingDirectory,
+                allowSolutions: true);
+
+            context.SourceSolutions.AddRange(
+                projectInfos
+                    .Where(p => p.SolutionFileName != null && IsSolutionFileName(p.SolutionFileName))
+                    .Select(p => p.SolutionFileName!)
+                    .Distinct()
+                    .OrderBy(p => p));
+
+            foreach (var solution in context.SourceSolutions)
+            {
+                Reporter.Info($"  Found: {Workspace.GetRelativePath(solution)}");
+            }
+        }
+
+        private void ExtractProjectsFromSources(Context context)
+        {
+            Reporter.Info("Extracting projects from source solutions");
+
+            foreach (var sourceSolution in context.SourceSolutions)
+            {
+                try
+                {
+                    var projects = GetProjectsFromSolution(sourceSolution);
+                    context.ProjectsBySource[sourceSolution] = projects;
+                    Reporter.Info($"  {Path.GetFileNameWithoutExtension(sourceSolution)}: {projects.Count} projects");
+                }
+                catch (Exception ex)
+                {
+                    Reporter.Error($"Failed to parse {sourceSolution}: {ex.Message}");
+                }
+            }
+        }
+
+        private void CreateOrValidateTargetSolution(Context context)
+        {
+            if (!File.Exists(context.TargetSolutionPath))
+            {
+                Reporter.Info($"Creating target solution: {Workspace.GetRelativePath(context.TargetSolutionPath)}");
+                
+                if (!Workspace.IsDryRun)
+                {
+                    DotNetCliHelper.CreateSolution(context.TargetSolutionPath);
+                }
+            }
+            else
+            {
+                Reporter.Info($"Target solution already exists: {Workspace.GetRelativePath(context.TargetSolutionPath)}");
+            }
+        }
+
+        private void ConsolidateProjectsToTarget(Context context)
+        {
+            Reporter.Info("Adding projects to target solution");
+
+            using (Reporter.BeginScope("Projects"))
+            {
+                foreach (var sourceSolution in context.SourceSolutions)
+                {
+                    var solutionFolderName = Path.GetFileNameWithoutExtension(sourceSolution);
+                    var projects = context.ProjectsBySource[sourceSolution];
+
+                    foreach (var project in projects)
+                    {
+                        var projectRelativePath = Workspace.GetRelativePath(project);
+                        
+                        if (!Workspace.IsDryRun)
+                        {
+                            DotNetCliHelper.AddProjectToSolution(
+                                project,
+                                context.TargetSolutionPath,
+                                solutionFolderName);
+                        }
+
+                        Reporter.Success($"  {projectRelativePath} -> {solutionFolderName}");
+                    }
+                }
+            }
+        }
+
+        private void GenerateSolutionFilters(Context context)
+        {
+            Reporter.Info("Generating solution filter files");
+
+            var targetSolutionRelativePath = Workspace.GetRelativePath(context.TargetSolutionPath);
+            var targetSolutionDirectory = Path.GetDirectoryName(context.TargetSolutionPath)!;
+
+            foreach (var sourceSolution in context.SourceSolutions)
+            {
+                var filterFileName = Path.ChangeExtension(sourceSolution, ".slnf");
+                var filterName = Path.GetFileNameWithoutExtension(sourceSolution);
+                var projects = context.ProjectsBySource[sourceSolution];
+
+                var projectIncludePaths = projects
+                    .Select(p => Path.GetRelativePath(targetSolutionDirectory, p))
+                    .OrderBy(p => p)
+                    .ToList();
+
+                var filter = new SolutionFilterJson
+                {
+                    Version = "0.1",
+                    DefaultFilter = filterName,
+                    Filters = new Dictionary<string, FilterDefinition>
+                    {
+                        {
+                            filterName,
+                            new FilterDefinition
+                            {
+                                Path = Path.GetRelativePath(targetSolutionDirectory, context.TargetSolutionPath),
+                                Includes = projectIncludePaths
+                            }
+                        }
+                    }
+                };
+
+                if (!Workspace.IsDryRun)
+                {
+                    var json = JsonSerializer.Serialize(filter, new JsonSerializerOptions 
+                    { 
+                        WriteIndented = true,
+                        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+                    });
+                    File.WriteAllText(filterFileName, json);
+                }
+
+                Reporter.Success($"  {Workspace.GetRelativePath(filterFileName)}");
+            }
+        }
+
+        private void CleanupSourceSolutions(Context context)
+        {
+            Reporter.Info("Cleaning up source solution files");
+
+            foreach (var sourceSolution in context.SourceSolutions)
+            {
+                if (!Workspace.IsDryRun)
+                {
+                    File.Delete(sourceSolution);
+                }
+
+                Reporter.Success($"  Deleted {Workspace.GetRelativePath(sourceSolution)}");
+            }
+        }
+
+        private class Context
+        {
+            public Command Command { get; set; } = null!;
+            public List<string> SourceSolutions { get; set; } = null!;
+            public string TargetSolutionPath { get; set; } = null!;
+            public Dictionary<string, List<string>> ProjectsBySource { get; set; } = null!;
+        }
+
+        private class SolutionFilterJson
+        {
+            public string? Version { get; set; }
+            public string? DefaultFilter { get; set; }
+            public Dictionary<string, FilterDefinition>? Filters { get; set; }
+        }
+
+        private class FilterDefinition
+        {
+            public string? Path { get; set; }
+            public List<string>? Includes { get; set; }
+        }
+    }
+}

--- a/DotNetPlease/Commands/CreateSolutionFilters.cs
+++ b/DotNetPlease/Commands/CreateSolutionFilters.cs
@@ -115,6 +115,7 @@ public static class CreateSolutionFilters
                 catch (Exception ex)
                 {
                     Reporter.Error($"Failed to parse {sourceSolution}: {ex.Message}");
+                    throw new InvalidOperationException($"Failed to parse source solution '{sourceSolution}'. Aborting conversion.", ex);
                 }
             }
         }

--- a/DotNetPlease/Commands/CreateSolutionFilters.cs
+++ b/DotNetPlease/Commands/CreateSolutionFilters.cs
@@ -84,15 +84,13 @@ public static class CreateSolutionFilters
         {
             Reporter.Info("Discovering source solutions");
 
-            var projectInfos = GetProjectInfosFromGlob(
+            var solutionFiles = FileSystemHelper.GetFileNamesFromGlob(
                 context.Command.From,
-                Workspace.WorkingDirectory,
-                allowSolutions: true);
+                Workspace.WorkingDirectory);
 
             context.SourceSolutions.AddRange(
-                projectInfos
-                    .Where(p => p.SolutionFileName != null && IsSolutionFileName(p.SolutionFileName))
-                    .Select(p => p.SolutionFileName!)
+                solutionFiles
+                    .Where(IsSolutionFileName)
                     .Distinct()
                     .OrderBy(p => p));
 


### PR DESCRIPTION
## Overview

Implements [Issue #49](https://github.com/morganstanley/dotnet-please/issues/49) to add a new command that converts multiple `.sln` files in a multi-solution repository into a single consolidated solution with individual `.slnf` (solution filter) files for each original solution.

This enables teams to migrate from a multi-solution structure to a monorepo while maintaining separate filtering options for different solution contexts.

## Command Syntax

```bash
please create-solution-filters --from <glob-pattern> --target <target-solution>
```

## Behavior

The command performs the following steps:

1. **Discovery**: Finds all `.sln` files matching the glob pattern
2. **Consolidation**: 
   - Creates or uses existing target solution
   - Extracts projects from each source solution
   - Adds them to the target under solution folders (named after source solutions)
3. **Filter Generation**: Creates `.slnf` JSON files for each original solution that filter the target solution to show only its original projects
4. **Cleanup**: Deletes source `.sln` files after successful conversion

## Example

**Before:**
```
Solution1.sln (contains ProjectA, ProjectB)
Solution2.sln (contains ProjectC, ProjectD)
```

**After running:** `please create-solution-filters --from "Solution*.sln" --target "Consolidated.sln"`

**Result:**
```
Consolidated.sln (contains all projects organized by solution folder)
├── Solution1/
│   ├── ProjectA
│   └── ProjectB
├── Solution2/
│   ├── ProjectC
│   └── ProjectD

Solution1.slnf (filters to Solution1's projects)
Solution2.slnf (filters to Solution2's projects)

Solution1.sln (deleted)
Solution2.sln (deleted)
```

## Implementation Details

- **Architecture**: Follows existing dotnet-please patterns (attribute-based command discovery, Mediator pattern)
- **Glob Support**: Reuses existing `MSBuildHelper.GetProjectInfosFromGlob()` for flexible pattern matching
- **CLI Integration**: Uses `DotNetCliHelper.AddProjectToSolution()` for reliable project addition via `dotnet sln` CLI
- **Solution Filters**: Generates valid JSON `.slnf` files with proper camelCase property names
- **Dry-Run Support**: Full integration with existing `--dry-run` flag
- **Error Handling**: Validates inputs (no matching solutions, invalid paths) and reports errors gracefully

## Testing

Added comprehensive unit tests covering:
- Two-solution consolidation (dry-run and live modes)
- Reuse of existing target solution
- Multiple projects per solution
- Single solution handling
- All tests use `[Theory, CombinatorialData]` for dry-run variations

**Result:** ✅ All 8 tests pass

## Files Changed

- **`DotNetPlease/Commands/CreateSolutionFilters.cs`** (255 lines): Command implementation
- **`DotNetPlease.Tests/Commands/CreateSolutionFiltersTests.cs`** (240 lines): Unit tests

## Notes

- Command is fully integrated and discoverable via `please --help`
- No breaking changes to existing functionality
- Leverages only existing helpers and standard .NET libraries (System.Text.Json)